### PR TITLE
Change to 14px the font in the table.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valudio/ui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "dist/index.js",
   "license": "MIT",
   "private": false,

--- a/src/components/Table/HeaderCell/styles.ts
+++ b/src/components/Table/HeaderCell/styles.ts
@@ -11,7 +11,7 @@ export default styled.div`
   .label {
     font-family: ${ ({ theme }) => theme.fontFamily };
     color: ${ ({ theme }) => theme.colors.typography.medium };
-    font-size: 16px;
+    font-size: 14px;
     margin: 0 14px 0 0;
   }
 

--- a/src/components/Table/Row/styles.ts
+++ b/src/components/Table/Row/styles.ts
@@ -21,7 +21,7 @@ export default styled.article`
     color: ${ ({ theme }) => theme.colors.typography.dark };
     margin: 0 16px;
     flex: 1;
-    font-size: 16px;
+    font-size: 14px;
     overflow: hidden;
     justify-content: flex-start;
   }


### PR DESCRIPTION
In this [commit](https://github.com/valudio/ui/commit/4b8e685b8f6c9a1c4042e50f56c5ff248ae905c6) we changed the font size to 16px to be aligned to the design. But is too big for some dependency projects, we should add the option to be configurable in the future.